### PR TITLE
Add .editorconfig plugin to .vimrc

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,7 @@ plugins=("https://github.com/ervandew/supertab.git" \
 	"https://github.com/vivien/vim-addon-linux-coding-style" \
 	"https://github.com/fatih/vim-go" \
         "https://github.com/SirVer/ultisnips" \
+        "https://github.com/editorconfig/editorconfig-vim.git" \
 )
 
 


### PR DESCRIPTION
Adds support for [`.editorconfig`](https://github.com/editorconfig/editorconfig-vim.git) files, which allows ViM to use project-specific formatting rules (i.e. tabs vs spaces, tab width, trailing whitespace deletion upon save, etc.).